### PR TITLE
added set_image() and display_image() to display an image

### DIFF
--- a/crates/control-plane/src/view.rs
+++ b/crates/control-plane/src/view.rs
@@ -1,5 +1,5 @@
 use eframe::{App, Frame};
-use eframe::egui::Context;
+use eframe::egui::{Context, TextureHandle, TextureOptions, Ui};
 
 pub enum Event {
 
@@ -11,17 +11,20 @@ pub trait ViewListener {
 
 pub struct View {
     listener: Option<Box<dyn ViewListener>>,
+    texture: Option<TextureHandle>,
 }
 
 impl App for View {
-    fn update(&mut self, ctx: &Context, frame: &mut Frame) {
-        // ...
+    fn update(&mut self, ctx: &Context, _frame: &mut Frame) {
+        eframe::egui::CentralPanel::default().show(ctx, |ui| {
+            self.display_image(ui);
+        });
     }
 }
 
 impl View {
     pub fn new() -> Self {
-        View { listener: None }
+        View { listener: None, texture: None }
     }
 
     pub fn open(self) {
@@ -35,5 +38,18 @@ impl View {
 
     pub fn set_listener(&mut self, listener: Box<dyn ViewListener>) {
         self.listener = Some(listener);
+    }
+
+    pub fn set_image(&mut self, ctx: &Context, width: u32, height: u32, image:Vec<u8>) {
+        let color_image = eframe::egui::ColorImage::from_rgba_unmultiplied([width as usize, height as usize], &image);
+        self.texture = Some(ctx.load_texture("image", color_image, TextureOptions::NEAREST, ));
+    }
+
+    fn display_image(&mut self, ui: &mut Ui) {
+        if let Some(image) = &self.texture {
+            ui.image((image.id(), image.size_vec2()));
+        } else {
+            ui.label("Render Output Area");
+        }
     }
 }


### PR DESCRIPTION
I have added set_image() and display_image() to display an image via the pixelbuffer. To call the set_image function use something like this: 

`   set_image(ctx, width, height, data);  //with data being Vec<u8>`

You can use this to test it with an example image (Optional):


 ```
 //in update()
        if self.texture.is_none() {
                    let width = 256;
                    let height = 256;
        
                    let mut data = Vec::with_capacity((width * height * 4) as usize);
                    for y in 0..height {
                        for x in 0..width {
                            data.push(x as u8);      // R
                            data.push(y as u8);      // G
                            data.push(128);          // B
                            data.push(255);          // A
                        }
                    }
        
                    self.set_image(ctx, width, height, data);
        }
```
