### PR TITLE
Remove upload artifact step from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,3 @@ jobs:
 
       - name: Build Docs
         run: cargo doc --no-deps --document-private-items
-
-      - name: Upload build artifact
-        if: runner.os == 'Linux' # optional: only upload once
-        uses: actions/upload-artifact@v4
-        with:
-          name: rust-binaries
-          path: target/release/


### PR DESCRIPTION
Removed the upload artifact step from CI workflow.
Because usage limit was hit and this step step is not vital.