### PR TITLE
fixed obj-parser crash when selecting object files without material

### DIFF
--- a/crates/scene-parser/src/lib.rs
+++ b/crates/scene-parser/src/lib.rs
@@ -14,9 +14,7 @@ mod tests {
         assert_eq!(result, 4);
     }
     #[test]
-    fn parse_json() {
-
-    }
+    fn parse_json() {}
 }
 pub struct Scene_Call;
 impl Scene_Parse_Trait for Scene_Call {

--- a/crates/scene/src/geometric_object.rs
+++ b/crates/scene/src/geometric_object.rs
@@ -111,7 +111,7 @@ impl FileObject for Sphere {
         self.attr.translation
     }
 }
-
+#[derive(Debug)]
 pub struct TriGeometry {
     triangles: Vec<Triangle>,
     attr: ObjConf,
@@ -147,17 +147,17 @@ impl FileObject for TriGeometry {
 
     fn get_scale(&self) -> Vec3 {
         //todo!()
-        Vec3::new(0.0,0.0,0.0)
+        Vec3::new(0.0, 0.0, 0.0)
     }
 
     fn get_translation(&self) -> Vec3 {
         //todo!()
-        Vec3::new(0.0,0.0,0.0)
+        Vec3::new(0.0, 0.0, 0.0)
     }
 
     fn get_rotation(&self) -> Vec3 {
         //todo!()
-        Vec3::new(0.0,0.0,0.0)
+        Vec3::new(0.0, 0.0, 0.0)
     }
 }
 impl TriGeometry {
@@ -191,6 +191,7 @@ impl TriGeometry {
         }
     }
 }
+#[derive(Debug)]
 pub struct Triangle {
     points: Vec<Vec3>, // todo: Probably introduces a typ for 3 3dPoints
     material: Option<Material>,
@@ -336,7 +337,7 @@ impl LightSource {
     pub fn rotate(&mut self, vec: Vec3) -> Vec3 {
         //todo!()
         // rotate and return new orientation?
-        Vec3::new(0.0,0.0,0.0)
+        Vec3::new(0.0, 0.0, 0.0)
     }
     pub fn get_name(&self) -> String {
         self.name.clone()
@@ -376,6 +377,16 @@ pub struct Material {
     transparency: f64,               //d
 }
 impl Material {
+    pub fn clone(material: &Material) -> Material {
+        let a = Material {
+            ambient_reflectivity: material.ambient_reflectivity.clone(),
+            diffuse_reflectivity: material.diffuse_reflectivity.clone(),
+            specular_reflectivity: material.specular_reflectivity.clone(),
+            shininess: material.shininess.clone(),
+            transparency: material.transparency.clone(),
+        };
+        a
+    }
     pub fn new(
         ambient_reflectivity: Vec<f64>,
         diffuse_reflectivity: Vec<f64>,
@@ -406,7 +417,7 @@ pub struct Color {
     pub g: f32,
     pub b: f32,
 }
-
+#[derive(Debug)]
 struct ObjConf {
     pub name: String,
     pub path: Option<String>,

--- a/crates/scene/src/lib.rs
+++ b/crates/scene/src/lib.rs
@@ -61,14 +61,10 @@ mod tests {
 
     #[test]
     fn parse() {
-        let mut scene = Scene::new();
-        /*let a = scene
-            .load_object_from_file("".to_string())
-            .unwrap();
-        scene.add_object(Box::new(a));
-        */
+        //let mut scene = Scene::new();
+        //let a = scene.load_object_from_file(".".to_string()).unwrap();
+        //scene.add_object(Box::new(a));
     }
-
 }
 pub trait Scene_Parse_Trait {
     fn do_scene_parse(&self, path: String) -> Scene;

--- a/crates/scene/src/obj_parser.rs
+++ b/crates/scene/src/obj_parser.rs
@@ -1,9 +1,9 @@
-use crate::geometric_object::{GeometricObject, Material, TriGeometry, Triangle};
+use crate::geometric_object::{Material, TriGeometry, Triangle};
 use anyhow::Error;
 use glam::Vec3;
 use std::path::Path;
 use tobj;
-pub fn parseobj(obj_path: String) -> Result<TriGeometry, Error> {
+pub fn parseobj(obj_path: String) -> Result<Vec<TriGeometry>, Error> {
     let obj_path = Path::new(&obj_path);
 
     // Load the OBJ file
@@ -17,10 +17,11 @@ pub fn parseobj(obj_path: String) -> Result<TriGeometry, Error> {
     )?;
     let amount_models = models.len();
     let mut z: usize = 0;
-    let mut return_Triangles: Vec<Triangle> = Vec::new();
+    let mut trivec: Vec<TriGeometry> = Vec::new();
+    let mut modelmaterialids: Vec<Option<usize>> = Vec::new();
     models.iter().for_each(|model| {
+        let mut return_triangles: Vec<Triangle> = Vec::new();
         z = 0;
-        //let triangles = TriGeometry::triangles(Vec::new());
         let mut vec: Vec<Vec3> = Vec::new();
         for i in 0..3 {
             while z < (model.mesh.positions.len() / 3) {
@@ -33,44 +34,56 @@ pub fn parseobj(obj_path: String) -> Result<TriGeometry, Error> {
                 z = z + 1;
             }
         }
-
-        let mut i = (model.mesh.indices.len() / 3);
+        let i = model.mesh.indices.len() / 3;
 
         for u in 0..i {
             let mut a = Triangle::new(Vec::new(), None);
             a.add_point(vec[model.mesh.indices[u * 3] as usize]);
             a.add_point(vec[model.mesh.indices[u * 3 + 1] as usize]);
             a.add_point(vec[model.mesh.indices[u * 3 + 2] as usize]);
-            return_Triangles.push(a);
+            return_triangles.push(a);
         }
+        trivec.push(TriGeometry::new(return_triangles));
+        modelmaterialids.push(model.mesh.material_id);
     });
 
     let mats: &tobj::Material;
-    let mut mat: Material = Material::default();
-    if let material = materials.unwrap() {
-        mats = material.first().unwrap();
-        mat = Material::new(
-            vec![
-                mats.ambient.unwrap()[0].into(),
-                mats.ambient.unwrap()[1].into(),
-                mats.ambient.unwrap()[2].into(),
-            ],
-            vec![
-                mats.diffuse.unwrap()[0].into(),
-                mats.diffuse.unwrap()[1].into(),
-                mats.diffuse.unwrap()[2].into(),
-            ],
-            vec![
-                mats.specular.unwrap()[0].into(),
-                mats.specular.unwrap()[1].into(),
-                mats.specular.unwrap()[2].into(),
-            ],
-            mats.shininess.unwrap().into(),
-            mats.dissolve.unwrap().into(),
-        );
+    let mut matvec: Vec<Material> = Vec::new();
+    let mate: Material = Material::default();
+    if let Ok(material) = materials {
+        //println!("materials: {}",material.len());
+        let mats = material.iter().for_each(|mats| {
+            matvec.push(Material::new(
+                vec![
+                    mats.ambient.unwrap_or([0.0,0.0,0.0])[0].into(),
+                    mats.ambient.unwrap_or([0.0,0.0,0.0])[1].into(),
+                    mats.ambient.unwrap_or([0.0,0.0,0.0])[2].into(),
+                ],
+                vec![
+                    mats.diffuse.unwrap_or([0.0,0.0,0.0])[0].into(),
+                    mats.diffuse.unwrap_or([0.0,0.0,0.0])[1].into(),
+                    mats.diffuse.unwrap_or([0.0,0.0,0.0])[2].into(),
+                ],
+                vec![
+                    mats.specular.unwrap_or([0.0,0.0,0.0])[0].into(),
+                    mats.specular.unwrap_or([0.0,0.0,0.0])[1].into(),
+                    mats.specular.unwrap_or([0.0,0.0,0.0])[2].into(),
+                ],
+                mats.shininess.unwrap_or(0.0).into(),
+                mats.dissolve.unwrap_or(0.0).into(),
+            ));
+        });
     }
-
-    let mut ret = TriGeometry::new(return_Triangles);
-    ret.set_material(mat);
-    Result::Ok(ret)
+    for (trigeo, id) in trivec.iter_mut().zip(modelmaterialids.into_iter()) {
+        if let Some(uid) = id {
+            trigeo.set_material(Material::clone(&matvec[uid]));
+        } else {
+            trigeo.set_material(Material::default());
+        }
+    }
+    //trivec.iter().for_each(|tri|println!("{}",tri.get_name()));
+    //println!("return {:?}",trivec,);
+    //println!("trivec: {:?}",trivec);
+    println!("parsed obj successfully");
+    Result::Ok(trivec)
 }

--- a/crates/scene/src/scene.rs
+++ b/crates/scene/src/scene.rs
@@ -2,9 +2,9 @@ use crate::geometric_object::LightType;
 use crate::obj_parser::parseobj;
 use crate::{
     action_stack::ActionStack,
-    call_scene_parse,
+    //call_scene_parse,
     geometric_object::{
-        Camera, GeometricObject, LightSource, Material, Rotation, Sphere, TriGeometry, Triangle,
+        Camera, GeometricObject, LightSource, Material, Rotation, Sphere, TriGeometry,
     },
     scene_graph::SceneGraph,
 };
@@ -32,12 +32,11 @@ impl Scene {
         //call_scene_parse()//to be fixed
         Scene::new()
     }
-    pub fn load_object_from_file(&mut self, path: String) -> Result<TriGeometry, Error> {
+    pub fn load_object_from_file(&mut self, path: String) -> Result<Vec<TriGeometry>, Error> {
         parseobj(path)
     }
-
     /*pub fn image_buffer(&self) -> Vec<u8> {
-        todo!()
+        //todo!()
         // render engine uses Vec<u8>, with 4 entries beeing one pixel. We might transform this to something else?
     }*/
     pub fn proto_init(&mut self) {


### PR DESCRIPTION
should not crash anymore, even if the wrong file is selected.