### PR TITLE
Add empty file export function

### DIFF
--- a/src/data_plane/scene/_scene.rs
+++ b/src/data_plane/scene/_scene.rs
@@ -166,4 +166,9 @@ impl Scene {
     pub fn set_background_color(&mut self, color: [f32; 3]) {
         self.background_color = color;
     }
+
+    #[allow(dead_code)]
+    pub fn export_render_img(&self, path: String) {
+        todo!()
+    }
 }

--- a/src/data_plane/scene_io.rs
+++ b/src/data_plane/scene_io.rs
@@ -1,2 +1,3 @@
+pub mod img_export;
 pub mod obj_parser;
 pub mod scene_parser;

--- a/src/data_plane/scene_io/img_export.rs
+++ b/src/data_plane/scene_io/img_export.rs
@@ -1,0 +1,6 @@
+use engine_wgpu_wrapper::RenderOutput;
+
+#[allow(dead_code)]
+pub fn export_img_png(_path: String, _render: RenderOutput) {
+    todo!()
+}


### PR DESCRIPTION
- Added function for file export in __scene.rs_ that _control_plane_ can use to pass the path (as String) where the last successfull render should be exported to. ---> export_render_img(&self, path: String)
- Added _img_export.rs_ in scene_io where the actual exporter will be
- I made sure that there are no warnings (allow dead code, todo!)