### PR TITLE
211 add temporary translate fn to renderconfig so loaded obj dont spawn inside the camera

### DIFF
--- a/crates/engine-config/src/render_config.rs
+++ b/crates/engine-config/src/render_config.rs
@@ -81,10 +81,9 @@ impl Validate for RenderConfig {
                 if !(0.0 < u.fov && u.fov < std::f32::consts::PI) {
                     return Err(RenderConfigBuilderError::FOVOutOfBounds);
                 }
-                // Add more Uniforms validation as needed
+                // TODO: Add more Uniforms validation as needed
             }
             Change::Delete => {
-                // If deleting uniforms is not allowed, error
                 return Err(RenderConfigBuilderError::CannotDeleteNonexistent);
             }
             Change::Keep => {}
@@ -95,11 +94,10 @@ impl Validate for RenderConfig {
                 if spheres.iter().any(|s| s.radius <= 0.0) {
                     return Err(RenderConfigBuilderError::InvalidSpheres);
                 }
-                // Add more Sphere validation as needed
+                // TODO: Add more Sphere validation as needed
             }
             Change::Delete => {
-                // If deleting spheres is not allowed, error
-                return Err(RenderConfigBuilderError::CannotDeleteNonexistent);
+                log::info!("RenderConfig: Attempting to delete spheres")
             }
             Change::Keep => {}
         }
@@ -111,7 +109,7 @@ impl Validate for RenderConfig {
                 }
             }
             Change::Delete => {
-                return Err(RenderConfigBuilderError::CannotDeleteNonexistent);
+                todo!("Implement Vertices Deletion")
             }
             Change::Keep => {}
         }
@@ -123,7 +121,7 @@ impl Validate for RenderConfig {
                 }
             }
             Change::Delete => {
-                return Err(RenderConfigBuilderError::CannotDeleteNonexistent);
+                todo!("Implement triangles Deletion")
             }
             Change::Keep => {}
         }

--- a/src/data_plane/scene/scene_engine_adapter.rs
+++ b/src/data_plane/scene/scene_engine_adapter.rs
@@ -154,7 +154,8 @@ impl Scene {
             // are kept as is. See: ../../../crates/engine-config/src/render_config.rs - `Change<T>`
             RenderConfigBuilder::new()
                 .uniforms(uniforms)
-                .spheres(render_spheres)
+                // TODO: Handle sphere deletion via state: `.spheres(render_spheres)`
+                .spheres_delete()
                 .vertices(all_vertices)
                 .triangles(all_triangles)
                 .build()


### PR DESCRIPTION
Adds a temporary translation function for testing translation, updates validation logic for geometry changes, and begins handling sphere deletion in the scene engine adapter (on new render for now).
Should be handled by a state in the data-plane.

```rust
#[allow(deprecated)]
rc.translate(0.0, 0.0, 2.0); // Translates everything in rc (spheres, triangles...) by 2.0 away from the camera
```