### PR TITLE
Added cargo docs to engine-wgpu-wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ glam = "0.30.9"
 engine-config = { version = "0.1.0", path = "crates/engine-config" }
 engine-pathtracer = { version = "0.1.0", path = "crates/engine-pathtracer" }
 engine-raytracer = { version = "0.1.0", path = "crates/engine-raytracer" }
-engine-bvh = {path = "crates/engine-bvh"}
+engine-bvh = { path = "crates/engine-bvh" }
 view-wrappers = { path = "crates/view-wrappers" }
 engine-wgpu-wrapper = { version = "0.1.0", path = "crates/engine-wgpu-wrapper" }
 log-buffer = { path = "crates/log-buffer" }
 clap = { version = "4.4.7", features = ["derive"] }
-scene-objects = { path = "crates/scene-objects"}
+scene-objects = { path = "crates/scene-objects" }
 image = "0.25.9"
 eframe-elements = { path = "crates/eframe-elements" }
 include_dir = "0.7.4"
@@ -40,5 +40,7 @@ members = [
     "crates/command-stack",
     "crates/log-buffer",
     "crates/scene-objects",
-    "crates/eframe-elements", "crates/engine-bvh", "crates/frame-buffer",
+    "crates/eframe-elements",
+    "crates/engine-bvh",
+    "crates/frame-buffer",
 ]

--- a/crates/engine-wgpu-wrapper/src/bind_group.rs
+++ b/crates/engine-wgpu-wrapper/src/bind_group.rs
@@ -1,10 +1,30 @@
 use crate::GpuBuffers;
 
+/// Wrapper for the `wgpu::BindGroupLayout`.
+///
+/// This struct defines the interface between the CPU resources (buffers) and the GPU shader.
+/// It specifies the type, visibility, and binding index of each resource.
 pub struct BindGroupLayout {
     pub bind_group_layout: wgpu::BindGroupLayout,
 }
 
 impl BindGroupLayout {
+    /// Creates the specific bind group layout used by the rendering engines.
+    ///
+    /// The bindings are as follows:
+    /// - 0: Uniforms Buffer (Read-Only Uniform)
+    /// - 1: Output Buffer (Read-Write Storage)
+    /// - 2: Spheres Buffer (Read-Only Storage)
+    /// - 3: Accumulation Buffer (Read-Write Storage)
+    /// - 4: Progressive Render Buffer (Read-Only Uniform)
+    /// - 5: Pointlight Buffer (Read-Only Storage)
+    /// - 6: Meshes Buffer (Read-Only Storage)
+    /// - 7: BVH Nodes Buffer (Read-Only Storage)
+    /// - 8: BVH Indices Buffer (Read-Only Storage)
+    /// - 9: BVH Triangles Buffer (Read-Only Storage)
+    /// - 10: UV Buffer (Read-Only Storage)
+    /// - 11: Texture Data Buffer (Read-Only Storage)
+    /// - 12: Texture Info Buffer (Read-Only Storage)
     pub fn new(device: &wgpu::Device) -> Self {
         let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("Main Bind Group Layout"),
@@ -161,11 +181,15 @@ impl BindGroupLayout {
     }
 }
 
+/// Wrapper for the `wgpu::BindGroup`.
+///
+/// This struct holds the actual resource bindings for a pipeline.
 pub struct BindGroup {
     pub bind_group: wgpu::BindGroup,
 }
 
 impl BindGroup {
+    /// Creates a new bind group by binding the provided `GpuBuffers` to the `BindGroupLayout`.
     pub fn new(
         device: &wgpu::Device,
         buffers: &GpuBuffers,

--- a/crates/engine-wgpu-wrapper/src/buffers.rs
+++ b/crates/engine-wgpu-wrapper/src/buffers.rs
@@ -7,33 +7,70 @@ use engine_bvh::bvh::BVHNode;
 use engine_bvh::triangle::GPUTriangle;
 use bytemuck::{Pod, Zeroable};
 
+/// Metadata for a texture stored in the global texture data buffer.
+///
+/// Since all textures are flattened into a single byte array, this struct
+/// provides the necessary information to index into that array.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Pod, Zeroable)]
 pub struct TextureInfo {
+    /// Offset in bytes into the `texture_data` buffer where this texture starts.
     pub offset: u32,
+    /// Width of the texture in pixels.
     pub width: u32,
+    /// Height of the texture in pixels.
     pub height: u32,
+    /// Padding to ensure 16-byte alignment (required for some GPU structures).
     pub _pad: u32,
 }
 
+/// Manages all GPU buffers used by the rendering engine.
+///
+/// This includes storage buffers for scene geometry (spheres, meshes), BVH structures,
+/// lights, and textures, as well as uniform buffers for camera and render settings.
+/// It also handles the output, staging, and accumulation buffers for the rendering process.
 pub struct GpuBuffers {
+    /// Storage buffer containing sphere definitions.
     pub spheres: Buffer,
+    /// Uniform buffer containing global render settings (camera, resolution, etc.).
     pub uniforms: Buffer,
+    /// Storage buffer for the compute shader output (write-only for shader).
     pub output: Buffer,
+    /// Staging buffer for reading back the output to the CPU (read-only for CPU).
     pub staging: Buffer,
+    /// Storage buffer containing UV coordinates.
     pub uvs: Buffer,
+    /// Storage buffer containing mesh definitions.
     pub meshes: Buffer,
+    /// Storage buffer for accumulating samples over multiple frames (progressive rendering).
     pub accumulation: Buffer,
+    /// Uniform buffer for progressive rendering state (pass count, etc.).
     pub progressive_render: Buffer,
+    /// Storage buffer containing point light definitions.
     pub lights: Buffer,
+    /// Storage buffer for BVH nodes.
     pub bvh_nodes: Buffer,
+    /// Storage buffer for BVH indices (references to triangles).
     pub bvh_indices: Buffer,
+    /// Storage buffer for BVH triangles (geometry data).
     pub bvh_triangles: Buffer,
+    /// Storage buffer containing raw texture pixel data (flattened).
     pub texture_data: Buffer,
+    /// Storage buffer containing metadata for accessing textures in `texture_data`.
     pub texture_info: Buffer,
 }
 
 impl GpuBuffers {
+    /// Creates a new set of GPU buffers based on the provided `RenderConfig`.
+    ///
+    /// This method initializes all buffers with the data from the configuration.
+    /// It expects the configuration fields to be in the `Change::Create` state.
+    ///
+    /// # Arguments
+    ///
+    /// * `rc` - The initial render configuration.
+    /// * `device` - The WGPU device used to create the buffers.
+    /// * `prh` - Helper for progressive rendering state.
     pub fn new(rc: &RenderConfig, device: &Device, prh: &ProgressiveRenderHelper) -> Self {
         let uniforms = match &rc.uniforms {
             Change::Create(u) => u,
@@ -110,6 +147,7 @@ impl GpuBuffers {
         }
     }
 
+    /// Flattens a list of textures into a single data vector and a corresponding info vector.
     pub fn process_textures(textures: &[TextureData]) -> (Vec<u32>, Vec<TextureInfo>) {
         let mut data = Vec::new();
         let mut info = Vec::new();
@@ -129,6 +167,7 @@ impl GpuBuffers {
         (data, info)
     }
 
+    /// Recreates the output, staging, and accumulation buffers to match a new resolution.
     pub fn grow_resolution(&mut self, device: &Device, size: u64) {
         self.output = Self::create_output_buffer(device, size);
         self.staging = Self::create_staging_buffer(device, size);
@@ -140,34 +179,42 @@ impl GpuBuffers {
         });
     }
 
+    /// Recreates the spheres buffer with new data.
     pub fn grow_spheres(&mut self, device: &Device, spheres: &[Sphere]) {
         self.spheres = Self::create_storage_buffer(device, "Spheres Buffer", spheres);
     }
 
+    /// Recreates the UVs buffer with new data.
     pub fn grow_uvs(&mut self, device: &Device, uvs: &[f32]) {
         self.uvs = Self::create_storage_buffer(device, "UVs Buffer", uvs);
     }
 
+    /// Recreates the meshes buffer with new data.
     pub fn grow_meshes(&mut self, device: &Device, meshes: &[Mesh]) {
         self.meshes = Self::create_storage_buffer(device, "Meshes Buffer", meshes);
     }
 
+    /// Recreates the lights buffer with new data.
     pub fn grow_lights(&mut self, device: &Device, lights: &[PointLight]) {
         self.lights = Self::create_storage_buffer(device, "Lights Buffer", lights);
     }
 
+    /// Recreates the BVH nodes buffer with new data.
     pub fn grow_bvh_nodes(&mut self, device: &Device, nodes: &[BVHNode]) {
         self.bvh_nodes = Self::create_storage_buffer(device, "BVH Nodes Buffer", nodes);
     }
 
+    /// Recreates the BVH indices buffer with new data.
     pub fn grow_bvh_indices(&mut self, device: &Device, indices: &[u32]) {
         self.bvh_indices = Self::create_storage_buffer(device, "BVH Indices Buffer", indices);
     }
 
+    /// Recreates the BVH triangles buffer with new data.
     pub fn grow_bvh_triangles(&mut self, device: &Device, triangles: &[GPUTriangle]) {
         self.bvh_triangles = Self::create_storage_buffer(device, "BVH Triangles Buffer", triangles);
     }
 
+    /// Recreates the texture data and info buffers with new texture data.
     pub fn grow_textures(&mut self, device: &Device, textures: &[TextureData]) {
         let (tex_data, tex_info) = Self::process_textures(textures);
         self.texture_data = Self::create_storage_buffer(device, "Texture Data Buffer", &tex_data);
@@ -219,38 +266,47 @@ impl GpuBuffers {
     }
 
     // Init methods for first-time creation
+    /// Initializes the uniforms buffer.
     pub fn init_uniforms(&mut self, device: &Device, uniforms: &Uniforms) {
         self.uniforms = Self::create_uniform_buffer(device, "Uniforms Buffer", uniforms);
     }
 
+    /// Initializes the spheres buffer.
     pub fn init_spheres(&mut self, device: &Device, spheres: &[Sphere]) {
         self.spheres = Self::create_storage_buffer(device, "Spheres Buffer", spheres);
     }
 
+    /// Initializes the UVs buffer.
     pub fn init_uvs(&mut self, device: &Device, uvs: &[f32]) {
         self.uvs = Self::create_storage_buffer(device, "UVs Buffer", uvs);
     }
 
+    /// Initializes the meshes buffer.
     pub fn init_meshes(&mut self, device: &Device, meshes: &[Mesh]) {
         self.meshes = Self::create_storage_buffer(device, "Meshes Buffer", meshes);
     }
 
+    /// Initializes the lights buffer.
     pub fn init_lights(&mut self, device: &Device, lights: &[PointLight]) {
         self.lights = Self::create_storage_buffer(device, "Lights Buffer", lights);
     }
 
+    /// Initializes the BVH nodes buffer.
     pub fn init_bvh_nodes(&mut self, device: &Device, nodes: &[BVHNode]) {
         self.bvh_nodes = Self::create_storage_buffer(device, "BVH Nodes Buffer", nodes);
     }
 
+    /// Initializes the BVH indices buffer.
     pub fn init_bvh_indices(&mut self, device: &Device, indices: &[u32]) {
         self.bvh_indices = Self::create_storage_buffer(device, "BVH Indices Buffer", indices);
     }
 
+    /// Initializes the BVH triangles buffer.
     pub fn init_bvh_triangles(&mut self, device: &Device, triangles: &[GPUTriangle]) {
         self.bvh_triangles = Self::create_storage_buffer(device, "BVH Triangles Buffer", triangles);
     }
 
+    /// Initializes the texture buffers.
     pub fn init_textures(&mut self, device: &Device, textures: &[TextureData]) {
         let (tex_data, tex_info) = Self::process_textures(textures);
         self.texture_data = Self::create_storage_buffer(device, "Texture Data Buffer", &tex_data);
@@ -258,38 +314,47 @@ impl GpuBuffers {
     }
 
     // Update methods for existing buffers
+    /// Updates the uniforms buffer by recreating it.
     pub fn update_uniforms(&mut self, device: &Device, uniforms: &Uniforms) {
         self.uniforms = Self::create_uniform_buffer(device, "Uniforms Buffer", uniforms);
     }
 
+    /// Updates the spheres buffer by recreating it.
     pub fn update_spheres(&mut self, device: &Device, spheres: &[Sphere]) {
         self.spheres = Self::create_storage_buffer(device, "Spheres Buffer", spheres);
     }
 
+    /// Updates the UVs buffer by recreating it.
     pub fn update_uvs(&mut self, device: &Device, uvs: &[f32]) {
         self.uvs = Self::create_storage_buffer(device, "UVs Buffer", uvs);
     }
 
+    /// Updates the meshes buffer by recreating it.
     pub fn update_meshes(&mut self, device: &Device, meshes: &[Mesh]) {
         self.meshes = Self::create_storage_buffer(device, "Meshes Buffer", meshes);
     }
 
+    /// Updates the lights buffer by recreating it.
     pub fn update_lights(&mut self, device: &Device, lights: &[PointLight]) {
         self.lights = Self::create_storage_buffer(device, "Lights Buffer", lights);
     }
 
+    /// Updates the BVH nodes buffer by recreating it.
     pub fn update_bvh_nodes(&mut self, device: &Device, nodes: &[BVHNode]) {
         self.bvh_nodes = Self::create_storage_buffer(device, "BVH Nodes Buffer", nodes);
     }
 
+    /// Updates the BVH indices buffer by recreating it.
     pub fn update_bvh_indices(&mut self, device: &Device, indices: &[u32]) {
         self.bvh_indices = Self::create_storage_buffer(device, "BVH Indices Buffer", indices);
     }
 
+    /// Updates the BVH triangles buffer by recreating it.
     pub fn update_bvh_triangles(&mut self, device: &Device, triangles: &[GPUTriangle]) {
         self.bvh_triangles = Self::create_storage_buffer(device, "BVH Triangles Buffer", triangles);
     }
 
+    /// Updates the texture buffers by recreating them.
     pub fn update_textures(&mut self, device: &Device, textures: &[TextureData]) {
         let (tex_data, tex_info) = Self::process_textures(textures);
         self.texture_data = Self::create_storage_buffer(device, "Texture Data Buffer", &tex_data);
@@ -297,40 +362,48 @@ impl GpuBuffers {
     }
 
     // Delete methods (create minimal empty buffers)
+    /// Replaces the uniforms buffer with a default/dummy one.
     pub fn delete_uniforms(&mut self, device: &Device) {
         let dummy_uniforms = Uniforms::default();
         self.uniforms =
             Self::create_uniform_buffer(device, "Uniforms Buffer (deleted)", &dummy_uniforms);
     }
 
+    /// Replaces the spheres buffer with an empty one.
     pub fn delete_spheres(&mut self, device: &Device) {
         self.spheres =
             Self::create_storage_buffer(device, "Spheres Buffer (deleted)", &[] as &[Sphere]);
     }
 
+    /// Replaces the UVs buffer with an empty one.
     pub fn delete_uvs(&mut self, device: &Device) {
         self.uvs = Self::create_storage_buffer(device, "UVs Buffer (deleted)", &[] as &[f32]);
     }
 
+    /// Replaces the meshes buffer with an empty one.
     pub fn delete_meshes(&mut self, device: &Device) {
         self.meshes =
             Self::create_storage_buffer(device, "Meshes Buffer (deleted)", &[] as &[Mesh]);
     }
 
+    /// Replaces the lights buffer with an empty one.
     pub fn delete_lights(&mut self, device: &Device) {
         self.lights = Self::create_storage_buffer(device, "Lights Buffer (deleted)", &[] as &[u32]);
     }
 
+    /// Replaces the BVH nodes buffer with an empty one.
     pub fn delete_bvh_nodes(&mut self, device: &Device) {
         self.bvh_nodes =
             Self::create_storage_buffer(device, "BVH Nodes Buffer (deleted)", &[] as &[BVHNode]);
     }
 
+    /// Replaces the BVH indices buffer with an empty one.
     pub fn delete_bvh_indices(&mut self, device: &Device) {
         self.bvh_indices =
             Self::create_storage_buffer(device, "BVH Indices Buffer (deleted)", &[] as &[u32]);
     }
 
+    /// Replaces the BVH triangles buffer with an empty one.
     pub fn delete_bvh_triangles(&mut self, device: &Device) {
         self.bvh_triangles = Self::create_storage_buffer(
             device,
@@ -339,6 +412,7 @@ impl GpuBuffers {
         );
     }
 
+    /// Replaces the texture buffers with empty ones.
     pub fn delete_textures(&mut self, device: &Device) {
         self.texture_data =
             Self::create_storage_buffer(device, "Texture Data Buffer (deleted)", &[] as &[u32]);

--- a/crates/engine-wgpu-wrapper/src/gpu_device.rs
+++ b/crates/engine-wgpu-wrapper/src/gpu_device.rs
@@ -1,12 +1,29 @@
 use std::sync::OnceLock;
 use anyhow::{Result, anyhow};
 
+/// Represents a handle to the GPU device and command queue.
+///
+/// This struct implements a singleton pattern using `OnceLock` to ensure that only one
+/// `wgpu::Device` and `wgpu::Queue` are created for the application, even if multiple
+/// engines or wrappers are instantiated.
 pub struct GpuDevice {
     pub(crate) device: wgpu::Device,
     pub(crate) queue: wgpu::Queue,
 }
 
 impl GpuDevice {
+    /// Acquires the GPU device and queue.
+    ///
+    /// If the device has not been initialized yet, it requests a high-performance adapter
+    /// and creates a logical device with limits suitable for the rendering tasks
+    /// (e.g., increased storage buffer limits).
+    ///
+    /// Subsequent calls return a clone of the existing device and queue handle.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(GpuDevice)` - A new instance containing the shared device and queue.
+    /// * `Err` - If no suitable adapter is found or device creation fails.
     pub fn new() -> Result<Self> {
         static DEVICE_ONCE: OnceLock<(wgpu::Device, wgpu::Queue)> = OnceLock::new();
 

--- a/crates/engine-wgpu-wrapper/src/lib.rs
+++ b/crates/engine-wgpu-wrapper/src/lib.rs
@@ -1,3 +1,39 @@
+//! # Engine WGPU Wrapper
+//!
+//! This crate provides a shared `wgpu` infrastructure for the rendering engines (`engine-raytracer` and `engine-pathtracer`).
+//! It encapsulates the boilerplate code required to set up a `wgpu` compute pipeline, manage buffers, handles binding groups
+//! and perform progressive rendering.
+//!
+//! ## Key Components
+//!
+//! - [`GpuWrapper`]: The main entry point, managing the device, queue, pipeline, and resources.
+//! - [`GpuBuffers`]: Manages all GPU buffers (uniforms, geometry, textures, accumulation, etc.).
+//! - [`BindGroup`] & [`BindGroupLayout`]: Defines and creates the bind groups used by the compute shaders.
+//! - [`ComputePipeline`]: Handles the creation of the wgpu compute pipeline and shader module loading.
+//! - [`GpuDevice`]: Provides a singleton-like access to the `wgpu::Device` and `wgpu::Queue`.
+//!
+//! ## Usage
+//!
+//! Engines typically instantiate `GpuWrapper` with a `RenderConfig` and the path to their specific shader file.
+//!
+//! ```rust,ignore
+//! use engine_wgpu_wrapper::GpuWrapper;
+//! use engine_config::RenderConfig;
+//!
+//! let rc = RenderConfig::default();
+//! let mut wrapper = GpuWrapper::new(rc, "path/to/shader.wgsl").unwrap();
+//!
+//! // Update resources
+//! wrapper.update(new_config).unwrap();
+//! wrapper.update_uniforms();
+//!
+//! // Execute compute pass
+//! wrapper.dispatch_compute().unwrap();
+//!
+//! // Read result
+//! let pixels = wrapper.read_pixels().unwrap();
+//! ```
+
 mod bind_group;
 mod buffers;
 pub mod gpu_device;

--- a/crates/engine-wgpu-wrapper/src/pipeline.rs
+++ b/crates/engine-wgpu-wrapper/src/pipeline.rs
@@ -1,11 +1,29 @@
 use std::fs;
 use std::path::Path;
 
+/// Wrapper for the `wgpu::ComputePipeline`.
+///
+/// This struct handles the loading of the WGSL shader source code and the creation
+/// of the compute pipeline using the provided bind group layout.
 pub struct ComputePipeline {
     pub pipeline: wgpu::ComputePipeline,
 }
 
 impl ComputePipeline {
+    /// Creates a new compute pipeline.
+    ///
+    /// It reads the shader source file from the path specified relative to the
+    /// `engine-wgpu-wrapper` crate root (using `CARGO_MANIFEST_DIR`).
+    ///
+    /// # Arguments
+    ///
+    /// * `device` - The wgpu device.
+    /// * `bind_group_layout` - The layout of the resources expected by the shader.
+    /// * `path` - The relative path to the WGSL shader file (e.g., `"../engine-raytracer/src/shader.wgsl"`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the shader file cannot be read or if pipeline creation fails.
     pub fn new(
         device: &wgpu::Device,
         bind_group_layout: &wgpu::BindGroupLayout,


### PR DESCRIPTION
This pull request adds documentation comments for the `engine-wgpu-wrapper` crate.

+ Formatted the Cargo.toml