### PR TITLE
Hotifixing shader include

### DIFF
--- a/crates/engine-pathtracer/src/lib.rs
+++ b/crates/engine-pathtracer/src/lib.rs
@@ -109,9 +109,10 @@ impl Engine {
     ///
     /// * `Self` - A new instance of the ray tracing engine.
     pub fn new(rc: RenderConfig) -> Self {
-        // TODO: The shader path is currently hardcoded relative to the project root.
-        // This might need to be made more robust for different execution contexts.
-        let wrapper = GpuWrapper::new(rc, "engine-pathtracer/src/shader.wgsl").unwrap();
+        // Embed the shader source code into the binary at compile time.
+        // This ensures the shader is available regardless of the execution environment.
+        let shader_source = include_str!("shader.wgsl");
+        let wrapper = GpuWrapper::new(rc, shader_source).unwrap();
         Self {
             gpu_wrapper: Arc::new(Mutex::new(wrapper)),
         }

--- a/crates/engine-raytracer/src/lib.rs
+++ b/crates/engine-raytracer/src/lib.rs
@@ -42,7 +42,8 @@ impl Engine {
     ///
     /// * `rc` - Initial render configuration
     pub fn new(rc: RenderConfig) -> Self {
-        let wrapper = GpuWrapper::new(rc, "engine-pathtracer/src/shader.wgsl").unwrap();
+        let shader_source = include_str!("shader.wgsl");
+        let wrapper = GpuWrapper::new(rc, shader_source).unwrap();
 
         Self {
             gpu_wrapper: wrapper,

--- a/crates/engine-wgpu-wrapper/src/gpu_wrapper.rs
+++ b/crates/engine-wgpu-wrapper/src/gpu_wrapper.rs
@@ -78,8 +78,8 @@ impl GpuWrapper {
     /// # Arguments
     ///
     /// * `rc` - The initial render configuration. Must contain `Change::Create` for all required fields.
-    /// * `path` - The path to the shader source file.
-    pub fn new(rc: RenderConfig, path: &str) -> Result<Self> {
+    /// * `shader_source` - The source code of the shader.
+    pub fn new(rc: RenderConfig, shader_source: &str) -> Result<Self> {
         let gpu = GpuDevice::new()?;
         let initial_uniforms = match rc.uniforms {
             Change::Create(u) | Change::Update(u) => u,
@@ -90,7 +90,7 @@ impl GpuWrapper {
         let buffers = GpuBuffers::new(&rc, &gpu.device, &prh);
         let layout = BindGroupLayout::new(&gpu.device);
         let groups = BindGroup::new(&gpu.device, &buffers, &layout.bind_group_layout);
-        let pipeline = ComputePipeline::new(&gpu.device, &layout.bind_group_layout, path);
+        let pipeline = ComputePipeline::new(&gpu.device, &layout.bind_group_layout, shader_source);
         Ok(Self {
             buffer_wrapper: buffers,
             bind_group_layout_wrapper: layout,

--- a/crates/engine-wgpu-wrapper/src/pipeline.rs
+++ b/crates/engine-wgpu-wrapper/src/pipeline.rs
@@ -1,6 +1,3 @@
-use std::fs;
-use std::path::Path;
-
 /// Wrapper for the `wgpu::ComputePipeline`.
 ///
 /// This struct handles the loading of the WGSL shader source code and the creation
@@ -12,22 +9,21 @@ pub struct ComputePipeline {
 impl ComputePipeline {
     /// Creates a new compute pipeline.
     ///
-    /// It reads the shader source file from the path specified relative to the
-    /// `engine-wgpu-wrapper` crate root (using `CARGO_MANIFEST_DIR`).
+    /// It uses the provided WGSL shader source code.
     ///
     /// # Arguments
     ///
     /// * `device` - The wgpu device.
     /// * `bind_group_layout` - The layout of the resources expected by the shader.
-    /// * `path` - The relative path to the WGSL shader file (e.g., `"../engine-raytracer/src/shader.wgsl"`).
+    /// * `shader_source` - The WGSL shader source code.
     ///
     /// # Panics
     ///
-    /// Panics if the shader file cannot be read or if pipeline creation fails.
+    /// Panics if pipeline creation fails.
     pub fn new(
         device: &wgpu::Device,
         bind_group_layout: &wgpu::BindGroupLayout,
-        path: &str,
+        shader_source: &str,
     ) -> Self {
         // Pipeline layout
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -36,15 +32,8 @@ impl ComputePipeline {
             immediate_size: 0,
         });
 
-        let path_new: &str = &(env!("CARGO_MANIFEST_DIR").to_owned() + "/../" + path);
-
-        let shader_path = Path::new(path_new);
-
-        let shader_source = fs::read_to_string(shader_path).unwrap();
-        // .unwrap_or_else(|_| panic!("Failed to read shader file: {:?}", shader_path));
-
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some(&format!("{} shader", path)),
+            label: Some("Compute Shader"),
             source: wgpu::ShaderSource::Wgsl(shader_source.into()),
         });
 


### PR DESCRIPTION
Instead of reading shader source files from disk at runtime, the shader code is now embedded directly into the binary at compile time using Rust's `include_str!` macro. This makes the engine more robust and portable across different execution environments, as it no longer relies on relative file paths or external files.